### PR TITLE
fix(process): skip the check for same process for a third-party log e.g. igneous)

### DIFF
--- a/provenancetoolbox/process.py
+++ b/provenancetoolbox/process.py
@@ -294,8 +294,11 @@ def process_absent(cloudvolume: cv.CloudVolume, process: Process) -> bool:
     logged = cloudvolume.provenance.processing
 
     def sameproc(loggedprocess: Process):
-        return (loggedprocess['task'] == process.description
-                and loggedprocess['parameters'] == jsonify(process.parameters))
+        result = False
+        if 'task' in loggedprocess and 'parameters' in loggedprocess:
+            result = (loggedprocess['task'] == process.description and
+                      loggedprocess['parameters'] == jsonify(process.parameters))
+        return result
 
     candidates = list(filter(sameproc, logged))
 


### PR DESCRIPTION
### Motivation
`provonence-toolbox` (PTB) assumes any item in the "processing" field of `cloud-volume`'s provenance is in a format defined by PTB. Unfortunately, it doesn't handle exceptions for formats that might come from other third-party tools. Specifically, `igneous` adds the "processing" field to the provenance in its own format while creating meshes for a segmentation, and PTB failed to recognize this.

### Solution
For now, omit any checks for the same process if it doesn't conform to the format defined by the PTB, which requires the existence of "task" and "parameters" fields.